### PR TITLE
Add SANOME_MEMORI number formatter

### DIFF
--- a/superset-frontend/src/setup/setupFormatters.ts
+++ b/superset-frontend/src/setup/setupFormatters.ts
@@ -21,11 +21,32 @@ import {
   getNumberFormatter,
   getNumberFormatterRegistry,
   NumberFormats,
+  NumberFormatter,
   getTimeFormatterRegistry,
   smartDateFormatter,
   smartDateVerboseFormatter,
 } from '@superset-ui/core';
 import { FormatLocaleDefinition } from 'd3-format';
+
+const sanomeMemoriFormatter: NumberFormatter = (value: number | null | undefined): string => {
+  if (value === null || value === undefined) {
+    console.warn("sanomeMemoriFormatter: value is null or undefined");
+    return '';
+  }
+  switch (value) {
+    case 1:
+      return 'Low';
+    case 2:
+      return 'Moderate';
+    case 3:
+      return 'High';
+    case 4:
+      return 'Critical';
+    default:
+      console.warn('sanomeMemoriFormatter: value is outside expected range');
+      return '';
+  }
+};
 
 export default function setupFormatters(
   d3Format: Partial<FormatLocaleDefinition>,
@@ -70,7 +91,8 @@ export default function setupFormatters(
     .registerValue(
       'DURATION_SUB',
       createDurationFormatter({ formatSubMilliseconds: true }),
-    );
+    ).
+    registerValue('SANOME_MEMORI', sanomeMemoriFormatter);
 
   getTimeFormatterRegistry()
     .registerValue('smart_date', smartDateFormatter)


### PR DESCRIPTION
Adds a custom number formatter, which converts numeric (integer) MEMORI risk levels back to words. This can be selected from the list of available formatters in the dashboard and used on the y-axis of a graph.
